### PR TITLE
Add US100 trading strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # GitCodeAsh
+
+This project demonstrates a simple US100 trading strategy based on moving
+average crossovers. It expects a CSV file containing historical US100 data
+and produces buy/sell signals.
+
+## Usage
+
+1. Place a CSV file containing US100 price data on disk. The file should
+   include columns: `Date`, `Open`, `High`, `Low`, `Close`, and `Volume`.
+2. Run the strategy:
+
+```bash
+python -m src.main path/to/us100.csv --output signals.csv
+```
+
+The resulting `signals.csv` will contain the original data with additional
+moving average columns and a `Signal` column indicating `buy` or `sell`
+actions.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""US100 trading strategy package."""

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+
+def add_moving_averages(df: pd.DataFrame, windows=(20, 50)) -> pd.DataFrame:
+    """Return a new DataFrame with moving average columns."""
+    result = df.copy()
+    for window in windows:
+        result[f"MA_{window}"] = df["Close"].rolling(window=window).mean()
+    return result

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from pathlib import Path
+
+
+def load_us100_csv(path: str | Path) -> pd.DataFrame:
+    """Load US100 trading data from a CSV file.
+
+    The CSV is expected to contain at least a `Date` column and OHLCV columns
+    such as `Open`, `High`, `Low`, `Close`, and `Volume`.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Data file not found: {path}")
+    df = pd.read_csv(path, parse_dates=["Date"])
+    df.sort_values("Date", inplace=True)
+    return df

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pandas as pd
+
+from .data_loader import load_us100_csv
+from .analyzer import add_moving_averages
+from .strategy import moving_average_crossover_signals
+
+
+def run_strategy(data_path: str | Path) -> pd.DataFrame:
+    df = load_us100_csv(data_path)
+    df = add_moving_averages(df)
+    df["Signal"] = moving_average_crossover_signals(df)
+    return df
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run simple US100 trading strategy")
+    parser.add_argument("data", help="Path to US100 CSV data file")
+    parser.add_argument("--output", help="Path to save results", default="signals.csv")
+    args = parser.parse_args()
+
+    result = run_strategy(args.data)
+    result.to_csv(args.output, index=False)
+    print(f"Signals saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def moving_average_crossover_signals(df: pd.DataFrame) -> pd.Series:
+    """Generate trading signals based on moving average crossover."""
+    signals = pd.Series(index=df.index, dtype="object")
+    above = df["MA_20"] > df["MA_50"]
+    signals[above & (~above.shift(1, fill_value=False))] = "buy"
+    signals[(~above) & above.shift(1, fill_value=False)] = "sell"
+    return signals


### PR DESCRIPTION
## Summary
- add package for a simple US100 trading strategy
- include data loader, analyzer, and basic moving average crossover logic
- document how to run the strategy in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847e5a340c48327a95dd311d8b17df1